### PR TITLE
change equals to obj equals instead of ==

### DIFF
--- a/crud-framework-hibernate5-connector/src/main/java/com/antelopesystem/crudframework/jpa/model/BaseJpaEntity.java
+++ b/crud-framework-hibernate5-connector/src/main/java/com/antelopesystem/crudframework/jpa/model/BaseJpaEntity.java
@@ -95,7 +95,7 @@ public abstract class BaseJpaEntity extends BaseCrudEntity<Long> {
 
 		BaseJpaEntity that = (BaseJpaEntity) o;
 
-		return getId() == that.getId();
+		return getId().equals(that.getId());
 	}
 
 	@Override


### PR DESCRIPTION
In questionnaireHandler there is a scenario where comparing answer ids will be false when they are the same